### PR TITLE
GPU Optimisations

### DIFF
--- a/mod5_resnet_feature_extractor.ipynb
+++ b/mod5_resnet_feature_extractor.ipynb
@@ -423,13 +423,34 @@
    "outputs": [],
    "source": [
     "# define the new loader with the bigger batchsize\n",
-    "loader_all = torch.utils.data.DataLoader(dataset, batch_size=128)\n",
+    "loader_all = torch.utils.data.DataLoader(dataset, batch_size=110)\n",
     "\n",
     "# initalize an empty dictonarty to store the features by image path\n",
-    "feat_dict = {}\n",
+    "feat_dict = {}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# if we are using a multiple GPU system with multiple users on it \n",
+    "# then we want to balance out which GPU we use. By default we'll\n",
+    "# just use GPU0. Randomly pick one to use.\n",
     "\n",
+    "gpu_id = random.randint(0,torch.cuda.device_count()-1)\n",
+    "print(\"using GPU\", gpu_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# put the network on the GPU\n",
-    "feat_extractor = feat_extractor.cuda()\n",
+    "feat_extractor = feat_extractor.cuda(device=gpu_id)\n",
     "\n",
     "# Activate evaluation mode\n",
     "feat_extractor.eval()\n",
@@ -444,7 +465,7 @@
     "        for inputs, labels, paths in t:\n",
     "            \n",
     "            # put the images onto the GPU\n",
-    "            inputs = inputs.cuda()\n",
+    "            inputs = inputs.cuda(device=gpu_id)\n",
     "            \n",
     "            # extract the features\n",
     "            feats_temp = feat_extractor(inputs)\n",
@@ -456,8 +477,7 @@
     "            temp_dict = {paths[ii]: feats_temp[ii, :] for ii in range(len(paths))}\n",
     "            \n",
     "            # update the output\n",
-    "            feat_dict.update(temp_dict)\n",
-    "\n"
+    "            feat_dict.update(temp_dict)"
    ]
   },
   {
@@ -664,7 +684,7 @@
     "feat_dict = {}\n",
     "\n",
     "# put the network on the GPU\n",
-    "feat_extractor = feat_extractor.cuda()\n",
+    "feat_extractor = feat_extractor.cuda(gpu_id)\n",
     "\n",
     "# tell the network not to compute gradients since we aren't training\n",
     "with torch.no_grad():\n",
@@ -672,7 +692,11 @@
     "    # use the tqdm module to monitor the progress of the extractor\n",
     "    with tqdm_notebook(loader_all, desc=\"Evaluating\") as t:\n",
     "        \n",
-    "        # for-loop goes here"
+    "        # for-loop goes here\n",
+    "\n",
+    "\n",
+    "# empty the GPU cache memory to free memory for other users\n",
+    "torch.cuda.empty_cache()"
    ]
   },
   {
@@ -785,13 +809,41 @@
     "\n",
     "# make a confusion matrix\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Free Up GPU memory when done\n",
+    "\n",
+    "GPU memory will remain in use until the kernel stops. Other users might need this memory to run their jobs. You can free all your memory by clicking \"Kernel -> Shutdown Kernel\". You will still be able to see any results you had visualised in your notebook but the state of all variables will be lost. \n",
+    "\n",
+    "We can also free some memory by running `torch.cuda.empty_cache()` while still keeping our kernel running and not losing any variable state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# empty the GPU cache memory to free memory for other users\n",
+    "torch.cuda.empty_cache()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "cv-workshop",
+   "display_name": "computer-vision-workshop",
    "language": "python",
-   "name": "cv-workshop"
+   "name": "computer-vision-workshop"
   },
   "language_info": {
    "codemirror_mode": {

--- a/mod6_fine_tuning.ipynb
+++ b/mod6_fine_tuning.ipynb
@@ -37,6 +37,7 @@
     "from torchvision.datasets import ImageFolder\n",
     "from torchvision.transforms import Compose, Resize, ToTensor\n",
     "from tqdm.notebook import tqdm, trange\n",
+    "import random\n",
     "\n",
     "sys.path.insert(1, os.path.join(os.getcwd(),'computer-vision-workshop/utilities'))\n",
     "from display_utils import imshow_tensor, make_confmat\n",
@@ -128,8 +129,15 @@
     "# reset the fully connect layer\n",
     "model.fc = nn.Linear(num_ftrs, len(dataset_train.classes))\n",
     "\n",
+    "# if we are using a multiple GPU system with multiple users on it \n",
+    "# then we want to balance out which GPU we use. By default we'll\n",
+    "# just use GPU0. Randomly pick one to use.\n",
+    "\n",
+    "gpu_id = random.randint(0,torch.cuda.device_count()-1)\n",
+    "print(\"using GPU\", gpu_id)\n",
+    "\n",
     "# Transfer model to GPU\n",
-    "model = model.cuda()"
+    "model = model.cuda(device=gpu_id)"
    ]
   },
   {
@@ -166,8 +174,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loader_train = torch.utils.data.DataLoader(dataset_train, batch_size=128,\n",
-    "                                           shuffle=True, num_workers=0)"
+    "loader_train = torch.utils.data.DataLoader(dataset_train, batch_size=110,\n",
+    "                                           shuffle=True, num_workers=1)"
    ]
   },
   {
@@ -185,12 +193,12 @@
     "    with tqdm(loader_train, desc=\"Training Epoch #{:d}\".format(epoch + 1)) as t:\n",
     "        for inputs, labels in t:\n",
     "            # Copy data to GPU\n",
-    "            inputs = inputs.cuda()\n",
-    "            labels = labels.cuda()\n",
+    "            inputs = inputs.cuda(device=gpu_id)\n",
+    "            labels = labels.cuda(device=gpu_id)\n",
     "    # for ii, data in enumerate(loader_train, 0):\n",
     "    #     inputs, labels = data\n",
-    "    #     inputs = inputs.cuda()\n",
-    "    #     labels = labels.cuda()\n",
+    "    #     inputs = inputs.cuda(device=gpu_id)\n",
+    "    #     labels = labels.cuda(device=gpu_id)\n",
     "            # zero the parameter gradients\n",
     "            optimizer.zero_grad()\n",
     "    \n",
@@ -203,7 +211,9 @@
     "            # print statistics\n",
     "            t.set_postfix(loss=loss.item())\n",
     "\n",
-    "print('Finished Training')"
+    "print('Finished Training')\n",
+    "# empty the GPU cache memory to free memory for other users\n",
+    "torch.cuda.empty_cache()"
    ]
   },
   {
@@ -239,7 +249,7 @@
     "print('Ground truth:', ', '.join('%5s' % dataset_val.classes[labels[j]] for j in range(4)))\n",
     "\n",
     "# Run the batch through the model\n",
-    "outputs = model(images.cuda())\n",
+    "outputs = model(images.cuda(device=gpu_id))\n",
     "\n",
     "# Collect the predicted classes\n",
     "_, predicted = torch.max(outputs, 1)\n",
@@ -265,7 +275,7 @@
     "labels_predicted = []\n",
     "\n",
     "# Validation data loader with a reasonable batch size\n",
-    "loader_val = torch.utils.data.DataLoader(dataset_val, batch_size=128, num_workers=0, shuffle=True)\n",
+    "loader_val = torch.utils.data.DataLoader(dataset_val, batch_size=110, num_workers=6, shuffle=True)\n",
     "\n",
     "# Activate evaluation mode\n",
     "model.eval()\n",
@@ -275,7 +285,7 @@
     "    with tqdm(loader_val, desc=\"Evaluating\") as t:\n",
     "        for inputs_batch, labels_batch in t:\n",
     "            # Copy data to GPU\n",
-    "            inputs_batch = inputs_batch.cuda()\n",
+    "            inputs_batch = inputs_batch.cuda(device=gpu_id)\n",
     "\n",
     "            outputs = model(inputs_batch)\n",
     "            _, predicted = torch.max(outputs.data, 1)\n",
@@ -295,7 +305,9 @@
     "print(classification_report(labels_true,\n",
     "                            labels_predicted,\n",
     "                            labels=np.arange(len(dataset_val.classes)),\n",
-    "                            target_names=dataset_val.classes))"
+    "                            target_names=dataset_val.classes))\n",
+    "# empty the GPU cache memory to free memory for other users\n",
+    "torch.cuda.empty_cache()"
    ]
   },
   {
@@ -314,7 +326,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "make_confmat(labels_true, labels_predicted, acc, labels=dataset_val.classes)"
    ]
   },
@@ -366,7 +378,7 @@
     "    with tqdm(loader_val, desc=\"Evaluating\") as t:\n",
     "        for input_batch, label_batch in t:\n",
     "            # Copy input batch to GPU\n",
-    "            input_batch = input_batch.cuda()\n",
+    "            input_batch = input_batch.cuda(device=gpu_id)\n",
     "\n",
     "            features_batch = feat_extractor(input_batch)\n",
     "            \n",
@@ -404,7 +416,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "fig, ax = plt.subplots()\n",
     "\n",
     "scat = ax.scatter(features_2d[:,0], features_2d[:,1], c=labels[:1000])\n",
@@ -421,6 +433,27 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Free Up GPU memory when done\n",
+    "\n",
+    "GPU memory will remain in use until the kernel stops. Other users might need this memory to run their jobs. You can free all your memory by clicking \"Kernel -> Shutdown Kernel\". You will still be able to see any results you had visualised in your notebook but the state of all variables will be lost. \n",
+    "\n",
+    "We can also free some memory by running `torch.cuda.empty_cache()` while still keeping our kernel running and not losing any variable state.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# empty the GPU cache memory to free memory for other users\n",
+    "torch.cuda.empty_cache()"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -430,9 +463,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "cv-workshop",
+   "display_name": "computer-vision-workshop",
    "language": "python",
-   "name": "cv-workshop"
+   "name": "computer-vision-workshop"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
-    Randomly selects a GPU where multiple GPUs are available
-    Optimises batch size to stay under 4GB of memory usage allowing up to four people to run this simultaneously on a 16GB P100.
-    Clears GPU cache after GPU operations to free up memory for other users
-    Optimised number of workers to minimise run time. Note this requires more than the default 64MB of shared memory, this is enabled on the test server and will be enabled on the live server on Monday.
-    Reminder to shutdown kernel at the end of the notebook
-    Fixed rendering issue in module 6 when generating the confusion matrix and TSNE plot.

